### PR TITLE
chore(ci): add a deletion policy to rds

### DIFF
--- a/deploy/controlplane.yaml
+++ b/deploy/controlplane.yaml
@@ -62,6 +62,9 @@ Resources:
 
   CPDatabase:
     Type: AWS::RDS::DBInstance
+    # The default is snapshot which is a good default but, we use this in CI where snapshots don't make sense
+    # If reusing this you probably don't want this deletionPolicy
+    DeletionPolicy: Delete
     Properties:
       DBName: kongmesh
       Engine: postgres


### PR DESCRIPTION
The default policy is to create a snapshot which is not what we want in our CI setup

We eventually hit the limit of 100 snapshots this will avoid this

Signed-off-by: Charly Molter <charly.molter@konghq.com>