### PR TITLE
Ethan iam policy clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ To enable this functionality, note that
   Value: "true"
 ```
 
+The `kuma-cp` task role also needs permissions to call `iam:GetRole` on any `kuma-dp` task roles. Add the following to your `kuma-cp` task role policy:
+
+```yaml
+- PolicyName: get-dataplane-roles
+  PolicyDocument:
+    Statement:
+      - Effect: Allow
+        Action:
+          - iam:GetRole
+        Resource:
+          - *
+```
+
 and we [add the following option to the `kuma-dp` container command](./deploy/counter-demo/demo-app.yaml#L251):
 
 ```yaml

--- a/deploy/controlplane.yaml
+++ b/deploy/controlplane.yaml
@@ -188,6 +188,14 @@ Resources:
                   - secretsmanager:PutSecretValue
                 Resource:
                   - !Ref APITokenSecret
+        - PolicyName: get-dataplane-roles
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - iam:GetRole
+                Resource:
+                 - *
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/CloudWatchFullAccess

--- a/deploy/controlplane.yaml
+++ b/deploy/controlplane.yaml
@@ -195,7 +195,7 @@ Resources:
                 Action:
                   - iam:GetRole
                 Resource:
-                 - *
+                  - *
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/CloudWatchFullAccess


### PR DESCRIPTION
It appears the `kuma-cp` task role needs to call `iam:GetRole` on `kuma-dp` task roles. Currently this permission is granted by the CloudWatchFullAccess policy. I feel that policy is a bit broad and users, like myself, might choose to grant individual API permissions when needed. 

In this case, I propose that it might be helpful to specifically call out all of the IAM permissions the `kuma-cp` task role needs, including `iam:GetRole` in a separate policy statement and in documentation.

Please feel free to share any feedback on this pull request you may have!

Thanks,
Ethan