### PR TITLE
fix: use verifyNone to connect to DB via TLS

### DIFF
--- a/deploy/controlplane.yaml
+++ b/deploy/controlplane.yaml
@@ -297,6 +297,8 @@ Resources:
               Value: kongmesh
             - Name: KUMA_STORE_POSTGRES_DB_NAME
               Value: kongmesh
+            - Name: KUMA_STORE_POSTGRES_TLS_MODE
+              Value: verifyNone
           Command: [migrate, up]
           LogConfiguration:
             LogDriver: awslogs
@@ -339,6 +341,8 @@ Resources:
               Value: kongmesh
             - Name: KUMA_STORE_POSTGRES_DB_NAME
               Value: kongmesh
+            - Name: KUMA_STORE_POSTGRES_TLS_MODE
+              Value: verifyNone
             - Name: KUMA_DP_SERVER_AUTH_TYPE
               Value: aws-iam
             - Name: KUMA_DP_SERVER_AUTH_USE_TOKEN_PATH


### PR DESCRIPTION
This seems me caused by RDS' `force_ssl` but it's not clear why this started failing last week. It may be that new instances started using PostgreSQL 15 which enforces this.