### PR TITLE
fix: don't assign public IPs to demo services

### DIFF
--- a/deploy/counter-demo/demo-app.yaml
+++ b/deploy/counter-demo/demo-app.yaml
@@ -178,7 +178,7 @@ Resources:
       ServiceName: !FindInMap [Config, Workload, Name]
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
+          AssignPublicIp: DISABLED
           Subnets:
             - Fn::ImportValue:
                 !Join [":", [!Ref "VPCStackName", "PublicSubnet"]]

--- a/deploy/counter-demo/redis.yaml
+++ b/deploy/counter-demo/redis.yaml
@@ -132,7 +132,7 @@ Resources:
       ServiceName: !FindInMap [Config, Workload, Name]
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
+          AssignPublicIp: DISABLED
           Subnets:
             - Fn::ImportValue: !Join [":", [!Ref VPCStackName, PublicSubnet]]
           SecurityGroups: [!Ref WorkloadSecurityGroup]


### PR DESCRIPTION
Likely left over from when these services had SSH running.