### PR TITLE
fix: revert "fix: don't assign public IPs to demo services (#43)"

### DIFF
--- a/deploy/counter-demo/demo-app.yaml
+++ b/deploy/counter-demo/demo-app.yaml
@@ -178,7 +178,7 @@ Resources:
       ServiceName: !FindInMap [Config, Workload, Name]
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
+          AssignPublicIp: ENABLED
           Subnets:
             - Fn::ImportValue:
                 !Join [":", [!Ref "VPCStackName", "PublicSubnet"]]

--- a/deploy/counter-demo/redis.yaml
+++ b/deploy/counter-demo/redis.yaml
@@ -132,7 +132,7 @@ Resources:
       ServiceName: !FindInMap [Config, Workload, Name]
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
+          AssignPublicIp: ENABLED
           Subnets:
             - Fn::ImportValue: !Join [":", [!Ref VPCStackName, PublicSubnet]]
           SecurityGroups: [!Ref WorkloadSecurityGroup]


### PR DESCRIPTION
Reverting due to issues connecting to secrets manager:

```
ResourceInitializationError: unable to pull secrets or registry auth: execution resource retrieval failed: unable to retrieve secret from asm: service call has been retried 5 time(s): failed to fetch secret arn:aws:secretsmanager:us-east-2:...:secret:ecs-ci/CPTLSCert/962_1-TxmoDc from secrets manager: RequestCanceled: request context canceled caused by: context deadline exceeded. Please check your task network configuration.
```

This reverts commit dc956f1d053b4b49c4cc8b59bfd51259e1df39ab.