### PR TITLE
chore(ecs): increase timeout for running the test

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -37,7 +37,7 @@ permissions:
 # credentials and then assume the aforementioned IAM role.
 jobs:
   test:
-    timeout-minutes: 30
+    timeout-minutes: 60
     name: "Test Kong Mesh on ECS"
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
I've noticed that some tests hit the timeout limit. Let's extend it and see if the issue still occurs. If it does, then we have a problem. Otherwise, it might be related to the software issue.