### PR TITLE
ci(cleanup): run even if the test failed

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -208,7 +208,7 @@ jobs:
   teardown:
     timeout-minutes: 30
     needs: test
-    name: "Cleanup after successful test"
+    name: "Cleanup"
     if: 'always() && !inputs.skip-cleanup'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The default behaviour is to skip if `test` failed, that causes resources to accumulate on AWS and later requires manual cleanup.
