### PR TITLE
ci(nightly): apply gateway policy before deploy

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -323,6 +323,26 @@ jobs:
               VPCStackName=${{ env.stack-prefix }}-vpc \
               CPStackName=${{ env.stack-prefix }}-cp \
             --template-file deploy/counter-demo/demo-app.yaml
+      # The gateway dataplane's :8080 listener is created by the MeshGateway
+      # policy. It must exist on the control plane before the gateway ECS
+      # service starts, otherwise the ELB health check on :8080 never passes,
+      # the service never reaches steady state and the stack deploy hangs until
+      # the job timeout. Apply it here instead of relying on a MeshGateway left
+      # over on the global CP from a previous run.
+      - name: Configure kumactl for Konnect
+        env:
+          konnect_token: ${{ secrets.KONNECT_CP_KPAT }}
+          konnect_cp_id: ${{ secrets.KONNECT_CP_ID }}
+        run: |
+          kumactl config control-planes add \
+            --address=https://us.api.konghq.com/v1/mesh/control-planes/${konnect_cp_id}/api \
+            --headers "authorization=Bearer ${konnect_token}" \
+            --name "konnect_ecs-global_us" \
+            --overwrite
+      - name: Apply gateway policies before provisioning gateway
+        run: |
+          kumactl apply -f resources/mesh.yaml
+          kumactl apply -f resources/meshgateway.yaml
       - name: Provision gateway
         run: |
           aws cloudformation deploy \
@@ -591,11 +611,12 @@ jobs:
             --name "konnect_ecs-global_us" \
             --overwrite
       - name: Cleanup HostnameGenerator
+        # Tolerate missing generators: if a deploy failed before policies were
+        # applied there is nothing to delete, and cleanup must not fail the run.
         run: |
-          kumactl delete hostnamegenerator mzms-hostnames
-          kumactl delete hostnamegenerator ms-local-hostnames
-          kumactl delete hostnamegenerator ms-synced-hostnames
-          kumactl delete hostnamegenerator mes-hostnames
+          for hg in mzms-hostnames ms-local-hostnames ms-synced-hostnames mes-hostnames; do
+            kumactl delete hostnamegenerator "${hg}" || true
+          done
 
   teardown:
     timeout-minutes: 30


### PR DESCRIPTION
## Motivation

The nightly multizone ECS workflow has failed every night since 2026-06-12. The `Deploy Zone us-east-2` job hits its 30-minute `timeout-minutes` and is cancelled; `apply-policies`, `test` and `teardown` are then skipped.

Root cause (verified live against a `skip-cleanup` run): the `ecs-ci-gateway` ECS service never reaches steady state. The gateway dataplane`s `:8080` listener is created by the `MeshGateway` policy, but `apply-policies` (which applies it) runs *after* both deploy jobs. So at gateway deploy time envoy loads `0 listeners`, the ELB health check on `:8080` fails, ECS crash-loops the task ("Task failed ELB health checks"), and the CloudFormation stack stays `CREATE_IN_PROGRESS` until the job times out.

It only ever passed because a `MeshGateway` persisted on the global CP from an earlier run (cleanup deletes only HostnameGenerators). Once that state was gone, every gateway deploy deadlocked. `gateway.yaml` already documents the dependency: "MeshGateway needs to be applied before because the LB healthCheck won`t pass".

> Changelog: skip

## Implementation information

- In `deploy-zone-east`, after the zone CP is provisioned and before the gateway stack deploys, configure kumactl for Konnect and apply `mesh.yaml` + `meshgateway.yaml`. This guarantees the `:8080` listener exists (synced to the zone) before the gateway ECS service starts, so ELB health checks pass and the stack reaches steady state.
- `apply-policies` still applies the full policy set afterwards (idempotent), including the HostnameGenerators that need both zones` hosted-zone IDs.
- Make `cleanup-policies` tolerant of missing HostnameGenerators (loop with `|| true`) so a failed deploy does not additionally fail cleanup.

Alternatives considered: pointing the gateway target group health check at a port the dataplane always opens (rejected — envoy admin is a unix socket here, no always-on TCP port); splitting the east deploy into base + gateway jobs around a policy job (larger refactor, not needed).

## Supporting documentation

Verified by a manual `workflow_dispatch` run with `skip-cleanup: true`: gateway envoy logged `loading 0 listener(s)` and only the `kuma:envoy:admin` socket; ECS reported `(port 8080) is unhealthy ... Health checks failed` and replaced the task repeatedly; the `ecs-ci-gateway` stack stayed `CREATE_IN_PROGRESS` for >11m until the 30m timeout.