### PR TITLE
ci(nightly): fix east teardown VPC deadlock

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -85,6 +85,25 @@ jobs:
       - name: Provision VPC
         id: vpc
         run: |
+          # A previous run may have left the stack in a state that
+          # `aws cloudformation deploy` can't recover from (e.g. a failed
+          # create rolls back to ROLLBACK_COMPLETE, which can't be updated).
+          # Delete it first so we start from a clean create.
+          status=$(
+            aws cloudformation describe-stacks --stack-name ${{ env.stack-prefix}}-vpc \
+              --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo MISSING
+          )
+          case "${status}" in
+            ROLLBACK_COMPLETE|ROLLBACK_FAILED|CREATE_FAILED|DELETE_FAILED|UPDATE_ROLLBACK_FAILED)
+              echo "VPC stack is in ${status}, deleting before redeploy..."
+              aws cloudformation delete-stack \
+                --stack-name ${{ env.stack-prefix}}-vpc \
+                --deletion-mode FORCE_DELETE_STACK
+              aws cloudformation wait stack-delete-complete \
+                --stack-name ${{ env.stack-prefix}}-vpc
+              ;;
+          esac
+
           aws cloudformation deploy \
             --capabilities CAPABILITY_IAM \
             --stack-name ${{ env.stack-prefix}}-vpc \
@@ -232,6 +251,25 @@ jobs:
       - name: Provision VPC
         id: vpc
         run: |
+          # A previous run may have left the stack in a state that
+          # `aws cloudformation deploy` can't recover from (e.g. a failed
+          # create rolls back to ROLLBACK_COMPLETE, which can't be updated).
+          # Delete it first so we start from a clean create.
+          status=$(
+            aws cloudformation describe-stacks --stack-name ${{ env.stack-prefix}}-vpc \
+              --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo MISSING
+          )
+          case "${status}" in
+            ROLLBACK_COMPLETE|ROLLBACK_FAILED|CREATE_FAILED|DELETE_FAILED|UPDATE_ROLLBACK_FAILED)
+              echo "VPC stack is in ${status}, deleting before redeploy..."
+              aws cloudformation delete-stack \
+                --stack-name ${{ env.stack-prefix}}-vpc \
+                --deletion-mode FORCE_DELETE_STACK
+              aws cloudformation wait stack-delete-complete \
+                --stack-name ${{ env.stack-prefix}}-vpc
+              ;;
+          esac
+
           aws cloudformation deploy \
             --capabilities CAPABILITY_IAM \
             --stack-name ${{ env.stack-prefix}}-vpc \
@@ -678,11 +716,22 @@ jobs:
           aws cloudformation wait stack-delete-complete \
             --stack-name ${{ env.stack-prefix}}-cp
 
-          aws secretsmanager delete-secret --secret-id ${{ matrix.region.tls-key-secret }}
-          aws secretsmanager delete-secret --secret-id ${{ matrix.region.tls-cert-secret }}
-          aws secretsmanager delete-secret --secret-id ${{ matrix.region.license-secret }}
-          aws secretsmanager delete-secret --secret-id ${{ matrix.region.cp-token-secret }}
+          # These IDs come from the deploy job's outputs, which are empty when
+          # the deploy failed before creating the secrets. Skip empty values so
+          # an empty --secret-id doesn't fail the step and skip VPC teardown.
+          for secret in \
+            "${{ matrix.region.tls-key-secret }}" \
+            "${{ matrix.region.tls-cert-secret }}" \
+            "${{ matrix.region.license-secret }}" \
+            "${{ matrix.region.cp-token-secret }}"; do
+            if [ -n "${secret}" ]; then
+              aws secretsmanager delete-secret --secret-id "${secret}" || true
+            fi
+          done
       - name: Deprovision VPC
+        # Always tear down the VPC, even if control-plane deprovision failed,
+        # so a broken VPC stack can't survive and block the next run's create.
+        if: always()
         run: |
           echo "Attempting to delete VPC stack..."
           if ! aws cloudformation delete-stack --stack-name ${{ env.stack-prefix}}-vpc; then

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -96,9 +96,13 @@ jobs:
           case "${status}" in
             ROLLBACK_COMPLETE|ROLLBACK_FAILED|CREATE_FAILED|DELETE_FAILED|UPDATE_ROLLBACK_FAILED)
               echo "VPC stack is in ${status}, deleting before redeploy..."
-              aws cloudformation delete-stack \
-                --stack-name ${{ env.stack-prefix}}-vpc \
-                --deletion-mode FORCE_DELETE_STACK
+              # FORCE_DELETE_STACK is only valid from DELETE_FAILED, so try a
+              # plain delete first and only force if that fails.
+              if ! aws cloudformation delete-stack --stack-name ${{ env.stack-prefix}}-vpc; then
+                aws cloudformation delete-stack \
+                  --stack-name ${{ env.stack-prefix}}-vpc \
+                  --deletion-mode FORCE_DELETE_STACK
+              fi
               aws cloudformation wait stack-delete-complete \
                 --stack-name ${{ env.stack-prefix}}-vpc
               ;;
@@ -262,9 +266,13 @@ jobs:
           case "${status}" in
             ROLLBACK_COMPLETE|ROLLBACK_FAILED|CREATE_FAILED|DELETE_FAILED|UPDATE_ROLLBACK_FAILED)
               echo "VPC stack is in ${status}, deleting before redeploy..."
-              aws cloudformation delete-stack \
-                --stack-name ${{ env.stack-prefix}}-vpc \
-                --deletion-mode FORCE_DELETE_STACK
+              # FORCE_DELETE_STACK is only valid from DELETE_FAILED, so try a
+              # plain delete first and only force if that fails.
+              if ! aws cloudformation delete-stack --stack-name ${{ env.stack-prefix}}-vpc; then
+                aws cloudformation delete-stack \
+                  --stack-name ${{ env.stack-prefix}}-vpc \
+                  --deletion-mode FORCE_DELETE_STACK
+              fi
               aws cloudformation wait stack-delete-complete \
                 --stack-name ${{ env.stack-prefix}}-vpc
               ;;


### PR DESCRIPTION
## Motivation

The nightly has failed since 2026-07-14 at `Deploy Zone us-east-2` / Provision VPC, with no code change in that window - it's a self-inflicted deadlock.

When the east deploy fails, its job outputs are empty.
Teardown then ran `aws secretsmanager delete-secret --secret-id` with an empty value, which fails with `ParamValidation`, so the step errored and the next step (`Deprovision VPC`) was skipped.
The broken VPC stack survived and blocked every subsequent run's create.

> Changelog: skip

## Implementation information

- skip empty secret IDs so an empty `--secret-id` can't fail the teardown step
- run `Deprovision VPC` with `if: always()` so it runs even when CP teardown fails
- self-heal `Provision VPC`: delete the stack first if it's in a non-updatable state (`ROLLBACK_COMPLETE` etc.)

## Supporting documentation

Teardown error confirmed in run 29308069340 (`Cleanup (us-east-2)` / Deprovision control plane): `argument --secret-id: expected one argument`, after which Deprovision VPC was skipped.
This prevents recurrence; the currently-stuck us-east-2 stack should be cleared by the new self-heal on the next run if it's in `ROLLBACK_COMPLETE`, otherwise it needs a one-time manual delete.