### PR TITLE
ci(actions): pin nightly to 2.14 previews

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,5 +1,5 @@
 name: "Nightly Kong Mesh on ECS Multizone"
-run-name: "Nightly Kong Mesh Multizone on ECS - ${{ inputs.version || 'preview' }}"
+run-name: "Nightly Kong Mesh Multizone on ECS - ${{ inputs.version || '2.14 preview' }}"
 
 concurrency:
   group: ${{github.workflow}}
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Kong Mesh version to build (same format as installer.sh). Otherwise latest preview is used.
+        description: Kong Mesh version to build (same format as installer.sh). Otherwise the latest preview of the pinned release branch is used.
         type: string
       skip-cleanup:
         description: Skip resource cleanup
@@ -23,6 +23,10 @@ on:
 env:
   stack-prefix: ecs-ci
   unique-id: ${{ github.run_number }}_${{ github.run_attempt}}
+  # Release branch the nightly tracks. `VERSION=preview` in installer.sh always
+  # resolves to master (it queries `0.0.0-preview`), which drifts ahead of the
+  # Konnect global CP and makes the zones NACK policies over KDS.
+  mesh-release: "2.14"
 
 permissions:
   id-token: write
@@ -75,7 +79,9 @@ jobs:
         run: |
           version="${{ inputs.version }}"
           if [[ -z "${version}" ]] || [[ "${version}" == "preview" ]]; then
-            version=$(curl --silent -L https://docs.konghq.com/mesh/installer.sh  | VERSION=preview sh -s - --print-version | tail -n1)
+            version=$(curl --silent \
+              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=1&query=filename%3A${{ env.mesh-release }}&sort=-date" \
+              --header 'accept: application/json' | jq -r '.[0].version')
           fi
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Install kumactl
@@ -222,7 +228,9 @@ jobs:
         run: |
           version="${{ inputs.version }}"
           if [[ -z "${version}" ]] || [[ "${version}" == "preview" ]]; then
-            version=$(curl --silent -L https://docs.konghq.com/mesh/installer.sh  | VERSION=preview sh -s - --print-version | tail -n1)
+            version=$(curl --silent \
+              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=1&query=filename%3A${{ env.mesh-release }}&sort=-date" \
+              --header 'accept: application/json' | jq -r '.[0].version')
           fi
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Install kumactl
@@ -358,7 +366,9 @@ jobs:
         run: |
           version="${{ inputs.version }}"
           if [[ -z "${version}" ]] || [[ "${version}" == "preview" ]]; then
-            version=$(curl --silent -L https://docs.konghq.com/mesh/installer.sh  | VERSION=preview sh -s - --print-version | tail -n1)
+            version=$(curl --silent \
+              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=1&query=filename%3A${{ env.mesh-release }}&sort=-date" \
+              --header 'accept: application/json' | jq -r '.[0].version')
           fi
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Install kumactl
@@ -573,7 +583,9 @@ jobs:
         run: |
           version="${{ inputs.version }}"
           if [[ -z "${version}" ]] || [[ "${version}" == "preview" ]]; then
-            version=$(curl --silent -L https://docs.konghq.com/mesh/installer.sh  | VERSION=preview sh -s - --print-version | tail -n1)
+            version=$(curl --silent \
+              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=1&query=filename%3A${{ env.mesh-release }}&sort=-date" \
+              --header 'accept: application/json' | jq -r '.[0].version')
           fi
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Install kumactl


### PR DESCRIPTION
## Motivation

The nightly resolves its Kong Mesh version with `VERSION=preview`, which bottoms out in `kuma.io/installer.sh`. That path queries Cloudsmith for `filename:0.0.0-preview` — and only master publishes under `0.0.0`. Release branches publish as `<version>-preview.v<sha>`, so `preview` can only ever mean master.

The Konnect global CP these zones federate with runs `2.14.2-preview.v7e1c15fbe`, so the nightly has been standing up 3.0 dev zones against a 2.14 global. On 2026-07-31 both zones NACKed policies over KDS during the initial sync:

- `MeshTrafficPermission` → `spec: policy must define rules`
- `MeshHTTPRoute` → `spec.targetRef.kind: value 'MeshGateway' is not supported; spec.to[*].targetRef.kind: value 'Mesh' is not supported; spec.to[*].hostnames: must not be defined`

Both messages come from validators that exist only on kuma master (`MeshTrafficPermission.spec.from` removal, built-in gateway API removal). Validation runs on the receiving side, so the newer zone rejected policies that are valid for the global that stores and sends them. The affected resources are silently dropped from the zone.

## Implementation information

- Resolve the version straight from the Cloudsmith preview repo, filtered to the tracked release branch, instead of going through `installer.sh --print-version`.
- Add a `mesh-release` workflow env var (`"2.14"`) so the next bump is a one-line change rather than four.
- Applied to all four `Get version` steps.

Resolves to `2.14.2-preview.v4651f56ad`, which matches the current `release-2.14` head (`4651f56ad9c2`). Verified the tag installs via `installer.sh` and that `kong/kuma-cp:2.14.2-preview.v4651f56ad` exists on Docker Hub, so the `Image=`/`SidecarImage=` arguments are unaffected. The GA tag `2.14.2` is not published under `kong/kuma-cp`, so tracking release-branch previews — not a GA tag — is what keeps the existing image references working.

`actionlint` reports the same two pre-existing SC2086 warnings before and after; no new findings.

## Supporting documentation

- Datadog: `service:mink "resource was rejected" status:error` — 4 events, tenant `afbd2df5-7c6f-4aa5-a064-d454d733267f`, zones `ecs-us-east-2` / `ecs-us-west-1`
- Validation source: `pkg/kds/v2/client/kds_client.go` (`UpstreamResponse.Validate`) and `pkg/util/xds/logging_callbacks.go` in kuma