### PR TITLE
ci(nightly): fix preview version resolution

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -79,9 +79,17 @@ jobs:
         run: |
           version="${{ inputs.version }}"
           if [[ -z "${version}" ]] || [[ "${version}" == "preview" ]]; then
+            # Cloudsmith `query` is a loose substring match: filtering on the
+            # release alone also matches builds like 2.12.14, so filter locally.
             version=$(curl --silent \
-              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=1&query=filename%3A${{ env.mesh-release }}&sort=-date" \
-              --header 'accept: application/json' | jq -r '.[0].version')
+              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=100&query=filename%3Alinux-amd64&sort=-date" \
+              --header 'accept: application/json' \
+              | jq -r --arg rel "${{ env.mesh-release }}." \
+                'map(select(.version | startswith($rel))) | .[0].version // empty')
+            if [[ -z "${version}" ]]; then
+              echo "::error::no ${{ env.mesh-release }} preview found in Cloudsmith"
+              exit 1
+            fi
           fi
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Install kumactl
@@ -251,9 +259,17 @@ jobs:
         run: |
           version="${{ inputs.version }}"
           if [[ -z "${version}" ]] || [[ "${version}" == "preview" ]]; then
+            # Cloudsmith `query` is a loose substring match: filtering on the
+            # release alone also matches builds like 2.12.14, so filter locally.
             version=$(curl --silent \
-              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=1&query=filename%3A${{ env.mesh-release }}&sort=-date" \
-              --header 'accept: application/json' | jq -r '.[0].version')
+              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=100&query=filename%3Alinux-amd64&sort=-date" \
+              --header 'accept: application/json' \
+              | jq -r --arg rel "${{ env.mesh-release }}." \
+                'map(select(.version | startswith($rel))) | .[0].version // empty')
+            if [[ -z "${version}" ]]; then
+              echo "::error::no ${{ env.mesh-release }} preview found in Cloudsmith"
+              exit 1
+            fi
           fi
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Install kumactl
@@ -432,9 +448,17 @@ jobs:
         run: |
           version="${{ inputs.version }}"
           if [[ -z "${version}" ]] || [[ "${version}" == "preview" ]]; then
+            # Cloudsmith `query` is a loose substring match: filtering on the
+            # release alone also matches builds like 2.12.14, so filter locally.
             version=$(curl --silent \
-              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=1&query=filename%3A${{ env.mesh-release }}&sort=-date" \
-              --header 'accept: application/json' | jq -r '.[0].version')
+              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=100&query=filename%3Alinux-amd64&sort=-date" \
+              --header 'accept: application/json' \
+              | jq -r --arg rel "${{ env.mesh-release }}." \
+                'map(select(.version | startswith($rel))) | .[0].version // empty')
+            if [[ -z "${version}" ]]; then
+              echo "::error::no ${{ env.mesh-release }} preview found in Cloudsmith"
+              exit 1
+            fi
           fi
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Install kumactl
@@ -649,9 +673,17 @@ jobs:
         run: |
           version="${{ inputs.version }}"
           if [[ -z "${version}" ]] || [[ "${version}" == "preview" ]]; then
+            # Cloudsmith `query` is a loose substring match: filtering on the
+            # release alone also matches builds like 2.12.14, so filter locally.
             version=$(curl --silent \
-              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=1&query=filename%3A${{ env.mesh-release }}&sort=-date" \
-              --header 'accept: application/json' | jq -r '.[0].version')
+              --url "https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=100&query=filename%3Alinux-amd64&sort=-date" \
+              --header 'accept: application/json' \
+              | jq -r --arg rel "${{ env.mesh-release }}." \
+                'map(select(.version | startswith($rel))) | .[0].version // empty')
+            if [[ -z "${version}" ]]; then
+              echo "::error::no ${{ env.mesh-release }} preview found in Cloudsmith"
+              exit 1
+            fi
           fi
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Install kumactl


### PR DESCRIPTION
## Motivation

> Changelog: skip

The nightly has failed every night since 2026-08-01 (last green: [run
30626738273](https://github.com/Kong/kong-mesh-ecs/actions/runs/30626738273)).
`Test cross-zone routing via ingress` exhausts all 10 attempts with
`Expected zone 'us-west-1' but got 'unknown'`, while the zone-local
dataplane tests pass.

Root cause is the version resolution added in #87. Cloudsmith's `query`
parameter is a loose substring match, so `filename:2.14` also matches
`kong-mesh-2.12.14-preview.*`. A `2.12.14-preview.v685377476` build was
published on 2026-07-31 18:43 UTC and became the newest match, so every
nightly since has deployed Kong Mesh 2.12 into zones federating with a
2.14 Konnect global CP. Zone-local traffic still works; cross-zone
routing through the zone ingress never converges.

Resolved versions per run:

| Run | Date | Resolved version | Result |
| --- | --- | --- | --- |
| 30626738273 | 07-31 11:21 | `2.14.2-preview.v5b3722f18` | pass |
| 30686081878 | 08-01 | `2.12.14-preview.v685377476` | fail |
| 30978090912 | 08-05 | `2.12.14-preview.v685377476` | fail |

## Implementation information

- Fetch a page of `linux-amd64` previews sorted by date and pick the
  newest whose version actually starts with `${mesh-release}.`, instead
  of trusting Cloudsmith to filter.
- Fail the job with an error annotation when no matching preview is
  found. Previously an unmatched query yielded `null` and the run
  carried on with a bogus version.
- Applied to all four jobs that resolve the version (west, east,
  policies, teardown).

## Supporting documentation

Verified against the live Cloudsmith API — the old query and the new one
on the same data:

```
# query=filename:2.14 (before)
2.12.14-preview.v685377476   <- picked
2.14.2-preview.v5b3722f18

# page + local startswith("2.14.") filter (after)
2.14.3-preview.v43c45e2a6    <- picked
```

`actionlint` reports no new findings (the two pre-existing SC2086 infos
in the teardown job are unchanged).

Note: the last green run also needed 6 of its attempts before ingress
routing converged, so the retry margin on that step is thin
independently of this fix.